### PR TITLE
fix unknown property 'publicPath' when build prod bundle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,7 @@ const disableCSSExtraction = (webpackConfig) => {
       x.use.forEach((use) => {
         if (use.loader && use.loader.includes("mini-css-extract-plugin"))
           use.loader = require.resolve("style-loader/dist/cjs.js");
+          delete use.options
       });
     }
   });


### PR DESCRIPTION
mini-css-extract-plugin have a options `{ publicPath: '../../' }`, when pass it to  style-loader, style-loader  will throw error with 
```
ValidationError: Invalid options object. Style Loader has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'publicPath'. These properties are valid:
   object { injectType?, attributes?, insert?, base?, esModule?, modules? }
```