### PR TITLE
Remove externals and make sure to respect craco defined webpack externals

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ module.exports = {
         entry: "src/single-spa-index.tsx", //defaults to src/index.js,
         orgPackagesAsExternal: false, // defaults to false. marks packages that has @my-org prefix as external so they are not included in the bundle
         reactPackagesAsExternal: true, // defaults to true. marks react and react-dom as external so they are not included in the bundle
-        externals: ["react-router","react-router-dom"], // defaults to []. marks the specified modules as external so they are not included in the bundle
         minimize: false // defaults to false, sets optimization.minimize value
       },
     }]


### PR DESCRIPTION
Fixes #18 removing `externals` from the plugin API and respecting the current defined externals in CRACO.

This is a **breaking** change so my suggestion for the maintainer is to update a major version on release.