### PR TITLE
FIX: ReferenceError: orgName is not defined

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,4 +19,4 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM-ACCESS-TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,4 +19,4 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_ACCESS_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,4 +19,4 @@ jobs:
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM-ACCESS-TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_ACCESS_TOKEN}}

--- a/src/override-webpack-config.js
+++ b/src/override-webpack-config.js
@@ -27,7 +27,7 @@ const buildOptimizations = (webpackMajorVersion, webpackConfig, minimize) => {
   return optimization;
 }
 
-const buildExternals = (webpackConfig, reactPackagesAsExternal, orgPackagesAsExternal) => {
+const buildExternals = (webpackConfig, reactPackagesAsExternal, orgPackagesAsExternal, orgName) => {
   const externals = [];
 
   if (webpackConfig.externals) {
@@ -99,7 +99,7 @@ const overrideWebpackConfig = ({
 
   const webpackMajorVersion = getWebpackMajorVersion();
   webpackConfig.optimization = buildOptimizations(webpackMajorVersion, webpackConfig, minimize);
-  webpackConfig.externals = buildExternals(webpackConfig, reactPackagesAsExternal, orgPackagesAsExternal);
+  webpackConfig.externals = buildExternals(webpackConfig, reactPackagesAsExternal, orgPackagesAsExternal, orgName);
 
   // Reference: https://github.com/systemjs/systemjs#compatibility-with-webpack
   if (webpackMajorVersion < 5) {


### PR DESCRIPTION
Due to not passing `orgName` as an argument in the buildExternals function. The apps are failing on version v2.0.1