### PR TITLE
fix: error when setting orgPackagesAsExternal=true

### DIFF
--- a/src/override-webpack-config.js
+++ b/src/override-webpack-config.js
@@ -27,7 +27,7 @@ const buildOptimizations = (webpackMajorVersion, webpackConfig, minimize) => {
   return optimization;
 }
 
-const buildExternals = (webpackConfig, reactPackagesAsExternal, orgPackagesAsExternal) => {
+const buildExternals = (webpackConfig, reactPackagesAsExternal, orgPackagesAsExternal, orgName) => {
   const externals = [];
 
   if (webpackConfig.externals) {
@@ -99,7 +99,7 @@ const overrideWebpackConfig = ({
 
   const webpackMajorVersion = getWebpackMajorVersion();
   webpackConfig.optimization = buildOptimizations(webpackMajorVersion, webpackConfig, minimize);
-  webpackConfig.externals = buildExternals(webpackConfig, reactPackagesAsExternal, orgPackagesAsExternal);
+  webpackConfig.externals = buildExternals(webpackConfig, reactPackagesAsExternal, orgPackagesAsExternal, orgName);
 
   // Reference: https://github.com/systemjs/systemjs#compatibility-with-webpack
   if (webpackMajorVersion < 5) {


### PR DESCRIPTION
Fix the error when setting the `orgPackagesAsExternal` option as true

### Example

```js
const orgName = 'myorg'

const singleSpaAppPlugin = {
  plugin: SingleSpaAppcracoPlugin,
  options: {
    orgName,
    projectName: 'container',
    entry: 'src/index.tsx', //defaults to src/index.js,
    orgPackagesAsExternal: true, // defaults to false. marks packages that has @my-org prefix as external so they are not included in the bundle
    reactPackagesAsExternal: true, // defaults to true. marks react and react-dom as external so they are not included in the bundle
    minimize:  process.env.IS_LOCAL !== 'true', // defaults to false, sets optimization.minimize value
    outputFilename: `${orgName }-container.js`, // defaults to the values set for the "orgName" and "projectName" properties, in this case "my-org-my-app.js"
  },
}
```

### Error
```bash
ReferenceError: orgName is not defined
    at buildExternals (C:\Users\pandrade\Documents\GitHub\console-container\node_modules\craco-plugin-single-spa-application\src\override-webpack-config.js:48:36)
    at Object.overrideWebpackConfig (C:\Users\pandrade\Documents\GitHub\console-container\node_modules\craco-plugin-single-spa-application\src\override-webpack-config.js:102:29)
    at overrideWebpack (C:\Users\pandrade\Documents\GitHub\console-container\node_modules\@craco\craco\dist\lib\features\plugins.js:36:38)       
    at C:\Users\pandrade\Documents\GitHub\console-container\node_modules\@craco\craco\dist\lib\features\plugins.js:53:29
    at Array.forEach (<anonymous>)
    at applyWebpackConfigPlugins (C:\Users\pandrade\Documents\GitHub\console-container\node_modules\@craco\craco\dist\lib\features\plugins.js:52:29)
    at mergeWebpackConfig (C:\Users\pandrade\Documents\GitHub\console-container\node_modules\@craco\craco\dist\lib\features\webpack\merge-webpack-config.js:119:70)
    at overrideWebpackDev (C:\Users\pandrade\Documents\GitHub\console-container\node_modules\@craco\craco\dist\lib\features\webpack\override.js:8:80)
    at C:\Users\pandrade\Documents\GitHub\console-container\node_modules\@craco\craco\dist\scripts\start.js:23:39

Node.js v18.16.0
```